### PR TITLE
Correct pallet link

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -270,7 +270,7 @@ ring_reload_modified:
 
 pallet:
   name: Pallet
-  url: http://hugoduncan.github.com/pallet/
+  url: http://pallet.github.com/pallet/
   category: Deployment Automation
 
 cascalog:


### PR DESCRIPTION
Everything pallet related is now at the pallet organisation on gitub https://github.com/pallet
