### PR TITLE
renames clj-hoptoad to clj-airbrake to reflect project change

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -43,9 +43,9 @@ ring_upload_progress:
   url: https://github.com/joodie/ring-upload-progress
   category: Request Middleware
 
-clj_hoptoad:
-  name: clj-hoptoad
-  url: https://github.com/leadtune/clj-hoptoad
+clj_airbrake:
+  name: clj-airbrake
+  url: https://github.com/leadtune/clj-airbrake
   category: Exception Handling
 
 compojure:


### PR DESCRIPTION
Bah, sorry about that last bogus pull request.  That is what I get for using github's in browser editor! :)
