### PR TITLE
Remove deprecated and broken clojars libraries

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -383,16 +383,6 @@ nrepl_el:
   url: https://github.com/kingtim/nrepl.el
   category: Emacs Integration
 
-lein_search:
-  name: lein-search
-  url: http://github.com/Licenser/lein-search
-  category: Clojars, Dependency Management
-
-lein_clojars:
-  name: lein-clojars
-  url: https://github.com/ato/lein-clojars
-  category: Clojars
-
 lein_namespace_depends:
   name: lein-namespace-depends
   url: https://github.com/hugoduncan/lein-namespace-depends


### PR DESCRIPTION
[lein-clojars](https://github.com/ato/lein-clojars) is deprecated as explained by the developer (lein now provides built-in support for deploying to Clojars), and [lein-search](https://github.com/Licenser/lein-search) doesn't work as it hasn't been updated in 3 years.
