### PR TITLE
Add "Static Typing" category to Schema

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1636,7 +1636,7 @@ core_typed:
 schema:
   name: Schema
   url: https://github.com/Prismatic/schema
-  category: Validation
+  category: Static Typing, Validation
 
 nginx_clojure:
   name: Nginx-Clojure


### PR DESCRIPTION
Schema seems to be as useful for imposing static type definitions as it is for validation of incoming data (and in fact, its roadmap lists deeper core.typed integration as an upcoming feature).
