### PR TITLE
Add Cursive Clojure and remove La Clojure

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -438,9 +438,9 @@ counterclockwise:
   url: http://code.google.com/p/counterclockwise/
   category: IDE Integration
 
-la_clojure:
-  name: La Clojure
-  url: http://plugins.intellij.net/plugin/?id=4050
+cursive:
+  name: Cursive Clojure
+  url: https://cursiveclojure.com
   category: IDE Integration
 
 wabbitmq:


### PR DESCRIPTION
This adds a link to Cursive Clojure, and removes La Clojure since it's no longer actively developed (see [here](http://devnet.jetbrains.com/thread/450673)).
