### PR TITLE
Add prism to continuous testing and removed lein-autotest

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -563,11 +563,6 @@ prism:
   url: https://github.com/aphyr/prism
   category: Continuous Testing
 
-lein_autotest:
-  name: lein-autotest
-  url: https://github.com/dakrone/lein-autotest
-  category: Continuous Testing
-
 lobos:
   name: Lobos
   url: http://budu.github.com/lobos


### PR DESCRIPTION
Added prism to Continuous testing, because it works really well.
Removed lein-autotest, because it is considered deprecated.
https://github.com/technomancy/leiningen/wiki/Plugins
