### PR TITLE
Removed inactive database migration library

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -728,11 +728,6 @@ clj-sql-up:
   url: https://github.com/ckuttruff/clj-sql-up
   category: Database Migrations
 
-kapooya:
-  name: Kapooya
-  url: https://github.com/bayan/kapooya
-  category: Database Migrations
-
 clj_aws_s3:
   name: clj-aws-s3
   url: https://github.com/weavejester/clj-aws-s3


### PR DESCRIPTION
The `Kapooya` database migration library is no longer actively worked on.
