### PR TITLE
FleetDB is now inactive

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -534,8 +534,8 @@ ritz:
   category: Debugging
 
 fleetdb:
-  name: FleetDB
-  url: http://fleetdb.org
+  name: FleetDB (inactive)
+  url: https://github.com/mmcgrana/fleetdb
   category: Databases
 
 jiraph:


### PR DESCRIPTION
FleetDB is no longer active, and the FleetDB.org site hosts a
wine-blog of all things.  Updated URL to point to the repository.
