### PR TITLE
Add the Duckling NLP time parser

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1992,3 +1992,8 @@ hikari-cp:
   name: hikari-cp
   url: https://github.com/tomekw/hikari-cp
   category: Connection Pools
+
+duckling:
+  name: Duckling
+  url: http://duckling-lib.org/
+  category: Date and Time, Parsing


### PR DESCRIPTION
Adds the [duckling](http://duckling-lib.org/) time parsing library which can be found at [this repo](https://github.com/wit-ai/duckling).
