### PR TITLE
Correct the clj-bigml repo URL

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1435,7 +1435,7 @@ clj_ml:
 
 clj_bigml:
   name: clj-bigml
-  url: https://github.com/antoniogarrote/clj-bigml
+  url: https://github.com/bigmlcom/clj-bigml
   category: Machine Learning
 
 enclog:


### PR DESCRIPTION
Currently the URL points to a non-existent repo.
