### PR TITLE
Corrected clj-http repo URL

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -135,7 +135,7 @@ ring:
 
 clj_http:
   name: clj-http
-  url: https://github.com/mmcgrana/clj-http
+  url: https://github.com/dakrone/clj-http 
   category: HTTP Clients
 
 ring_httpcore_adapter:


### PR DESCRIPTION
Old link [1] wasn't active for a few years. README file at the inactive repo redirects to the current active repository [2].

[1] https://github.com/mmcgrana/clj-http
[2] https://github.com/dakrone/clj-http