### PR TITLE
One more Ring Session library

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -117,6 +117,11 @@ rrss:
   name: RRSS
   url: https://github.com/paraseba/rrss
   category: Ring Sessions
+  
+ring_ttl_session:
+  name: ring-ttl-session
+  url: https://github.com/boechat107/ring-ttl-session
+  category: Ring Sessions
 
 mongodb_session:
   name: mongodb-session


### PR DESCRIPTION
Copying from the project's description:

> "A session storage that stores session data in-memory with a time-to-live (TTL).
It's very similar to ring.middleware.session.memory, but it uses core.cache 
instead of a Clojure's native map."