### PR TITLE
Fix key for clecs, so that brute doesn't get hidden.

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1948,7 +1948,7 @@ play_clj:
   url: https://github.com/oakes/play-clj
   category: Game Development
 
-brute:
+clecs:
   name: clecs
   url: https://github.com/muhuk/clecs
   category: Game Development


### PR DESCRIPTION
Fix for bad key which was introduced in issue #106, hiding the brute project from the list.