### PR TITLE
Add mpenet/spandex to elasticsearch clients

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1311,6 +1311,12 @@ elastisch:
   url: https://github.com/clojurewerkz/elastisch
   categories: [ElasticSearch Clients, Text Search]
   platforms: [clj]
+  
+spandex:
+  name: Spandex
+  url: https://github.com/mpenet/spandex
+  categories: [ElasticSearch Clients, Text Search]
+  platforms: [clj]
 
 crouton:
   name: Crouton


### PR DESCRIPTION
Hi James, 

This is a new lib that's built on the new low level rest client introduced by ES 5.x. It's simple but quite capable already.

https://github.com/mpenet/spandex