### PR TITLE
Add Toucan lightweight-ORM

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -3657,3 +3657,9 @@ sibiro:
   url: https://github.com/aroemers/sibiro
   categories: [HTTP Routing]
   platforms: [clj, cljs]
+  
+toucan:
+  name: toucan
+  url: https://github.com/camsaul/toucan
+  categories: [SQL Abstraction]
+  platforms: [clj]

--- a/projects.yml
+++ b/projects.yml
@@ -3660,6 +3660,6 @@ sibiro:
   
 toucan:
   name: toucan
-  url: https://github.com/camsaul/toucan
+  url: https://github.com/metabase/toucan
   categories: [SQL Abstraction]
   platforms: [clj]


### PR DESCRIPTION
Hey, first of all, awesome guide!

I'd like to add a link for [Toucan](https://github.com/metabase/toucan), a sort of lightweight-ORM for Clojure. It's based on the internal utility functions we've been building for two years or so as part of [Metabase](https://github.com/metabase/metabase) 😎