### PR TITLE
Add raml-clj-parser to RAML parsers

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -460,6 +460,12 @@ clj_yaml:
   categories: [YAML Parsers]
   platforms: [clj]
 
+raml_clj_parser:
+  name: raml-clj-parser
+  url: https://github.com/zacyang/raml-clj-parser
+  categories: [RAML Parsers]
+  platforms: [clj]  
+
 tubax:
   name: tubax
   url: https://github.com/funcool/tubax


### PR DESCRIPTION
I've created a simple library which is able to parse RAML v0.8 into clojure map [raml-clj-parser](https://github.com/zacyang/raml-clj-parser), and I would like to put it on the toolbox list. It would be nice if you can accept this PR.

Thanks.