### PR TITLE
Add celtuce

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -424,6 +424,12 @@ clj_redis:
   categories: [Redis Clients]
   platforms: [clj]
 
+celtuce:
+  name: celtuce
+  url: https://github.com/lerouxrgd/celtuce
+  categories: [Redis Clients]
+  platforms: [clj]
+
 metis:
   name: Metis
   url: https://github.com/mylesmegyesi/metis


### PR DESCRIPTION
Celtuce is a thin idiomatic wrapper around Lettuce, a powerful Java Redis client