### PR TITLE
Adds pmonks/multigrep and pmonks/spinner to projects list

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -3705,7 +3705,7 @@ sibiro:
   url: https://github.com/aroemers/sibiro
   categories: [HTTP Routing]
   platforms: [clj, cljs]
-  
+
 toucan:
   name: Toucan
   url: https://github.com/metabase/toucan
@@ -3764,4 +3764,10 @@ ring-accept-param:
   name: ring-accept-param
   url: https://github.com/gmazelier/ring-accept-param
   categories: [Content Negotiation, Request Middleware]
+  platforms: [clj]
+
+multigrep:
+  name: multigrep
+  url: https://github.com/pmonks/multigrep
+  categories: [Filesystem Utilities]
   platforms: [clj]

--- a/projects.yml
+++ b/projects.yml
@@ -3771,3 +3771,10 @@ multigrep:
   url: https://github.com/pmonks/multigrep
   categories: [Filesystem Utilities]
   platforms: [clj]
+
+spinner:
+  name: spinner
+  url: https://github.com/pmonks/spinner
+  categories: [Command Line Tools]
+  platforms: [clj]
+


### PR DESCRIPTION
This PR adds the following two projects to the projects list:

1. [pmonks/multigrep](https://github.com/pmonks/multigrep)
2. [pmonks/spinner](https://github.com/pmonks/spinner)