### PR TITLE
Maintenance on project URLs

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -706,12 +706,6 @@ session_expiry:
   categories: [Ring Sessions]
   platforms: [clj]
 
-ring_session_riak:
-  name: ring-session-riak
-  url: https://github.com/ossareh/ring-session-riak
-  categories: [Ring Sessions]
-  platforms: [clj]
-
 clout:
   name: Clout
   url: http://github.com/weavejester/clout
@@ -720,13 +714,13 @@ clout:
 
 counterclockwise:
   name: Counterclockwise
-  url: http://code.google.com/p/counterclockwise/
+  url: https://github.com/ccw-ide/ccw
   categories: [IDE Integration]
   platforms: [clj]
 
 cursive:
   name: Cursive Clojure
-  url: https://cursiveclojure.com
+  url: https://cursive-ide.com
   categories: [IDE Integration]
   platforms: [clj]
 
@@ -876,7 +870,7 @@ jiraph:
 
 clj_digest:
   name: digest
-  url: https://bitbucket.org/tebeka/clj-digest/src
+  url: https://github.com/tebeka/clj-digest
   categories: [Cryptography, Hashing]
   platforms: [clj]
 
@@ -2634,13 +2628,7 @@ misaki:
 
 madness:
   name: Madness
-  url: http://algernon.github.io/madness/
-  categories: [Static Site Generation]
-  platforms: [clj]
-
-static:
-  name: Static
-  url: http://algernon.github.io/madness/
+  url: https://github.com/algernon/madness
   categories: [Static Site Generation]
   platforms: [clj]
 
@@ -2790,7 +2778,7 @@ stch_ns:
 
 expectations:
   name: Expectations
-  url: http://jayfields.com/expectations/
+  url: https://clojure-expectations.github.io
   categories: [Unit Testing]
   platforms: [clj]
 
@@ -2840,12 +2828,6 @@ clj-pgp:
   name: clj-pgp
   url: https://github.com/greglook/clj-pgp
   categories: [Cryptography]
-  platforms: [clj]
-
-zeus:
-  name: zeus
-  url: https://github.com/chmllr/zeus
-  categories: [Compression]
   platforms: [clj]
 
 swindon:


### PR DESCRIPTION
I did a link check on `projects.yml`. That is, I ran HTTP requests to
all the URLs from the REPL and checked out the ones that didn’t return
status 200. I hope you don’t mind me doing this!

*   `404` ossareh/ring-session-riak: vanished, unable to find anything
    via web search
*   `405` Counterclockwise: active, but no longer available on Google code
*   Cursive redirects to new site
*   `404` clj-digest: active, moved to GitHub
*   `404` Madness: active, no github.io site
*   `404` Expectations: active, now a github.io site
*   `404` chmllr/zeus: vanished, unable to find anything via web search

`http://let-caribou.in/` returned a 502 Bad Gateway, but this may be
temporary.
