### PR TITLE
Add Uruk to Databases category and to new MarkLogic Clients category

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -3861,3 +3861,9 @@ dynadoc:
   url: https://github.com/oakes/Dynadoc
   categories: [Documentation Tools]
   platforms: [clj, cljs]
+
+uruk:
+  name: Uruk
+  url: https://github.com/daveliepmann/uruk
+  categories: [Databases, MarkLogic Clients]
+  platforms: [clj]


### PR DESCRIPTION
My library Uruk is a MarkLogic database client. This PR adds the project to the project listing and creates a new category of "MarkLogic Clients".