### PR TITLE
Remove madness and ecstatic libraries.

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -2686,18 +2686,6 @@ misaki:
   categories: [Static Site Generation]
   platforms: [clj]
 
-madness:
-  name: Madness
-  url: https://github.com/algernon/madness
-  categories: [Static Site Generation]
-  platforms: [clj]
-
-ecstatic:
-  name: Ecstatic
-  url: https://github.com/samrat/ecstatic
-  categories: [Static Site Generation]
-  platforms: [clj]
-
 incise:
   name: Incise
   url: https://github.com/RyanMcG/incise


### PR DESCRIPTION
Ecstatic is [no longer maintained](https://samrat.me/projects/).

Madness lacks documentation. Judging from the [readme](https://github.com/algernon/madness), the docs used to be a github.io page, but that 404s out now.