### PR TITLE
Adding following libraries: where, clj-sophia, ring-boost

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -4005,3 +4005,21 @@ system_viz:
   url: https://github.com/walmartlabs/system-viz
   categories: [Visualization, Application Frameworks]
   platforms: [clj]
+
+where:
+  name: where
+  url: https://github.com/BrunoBonacci/where
+  categories: [DSL, Utilities]
+  platforms: [clj, cljs]
+
+clj-sophia:
+  name: clj-sophia
+  url: https://github.com/BrunoBonacci/clj-sophia
+  categories: [Databases]
+  platforms: [clj]
+
+ring-boost:
+  name: ring-boost
+  url: https://github.com/BrunoBonacci/ring-boost
+  categories: [Caching, Request Middleware, Response Middleware]
+  platforms: [clj]


### PR DESCRIPTION
 * `where`
`where` is a library to create expressive predicate functions and contains a set of built-in comparators which are nil-safe and easy to use. Very useful when creating complex filters on data or to support a DSL.

* `clj-sophia`
A Clojure driver for Sophia DB. Sophia is RAM-Disk hybrid storage designed to provide best possible on-disk performance without degradation in time.

* `ring-boost`
I library to boost performances of Clojure web applications with **off-heap serverside** caching.
