### PR TITLE
Add project otarta

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -4137,3 +4137,9 @@ clucie:
   url: https://github.com/federkasten/clucie
   categories: [Text Search]
   platforms: [clj]
+
+otarta:
+  name: Otarta
+  url: https://gitlab.com/eval/otarta
+  categories: [Message Queues, MQTT]
+  platforms: [cljs]


### PR DESCRIPTION
This PR adds Otarta, an MQTT-library for ClojureScript.

As 'Message Queues' is a broad category, I added MQTT so people who search for it on the page will find it. Hope that's ok.