### PR TITLE
Add a few linters I think would be good additions

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -2842,6 +2842,24 @@ eastwood:
   categories: [Code Analysis, Leiningen Plugins]
   platforms: [clj]
 
+bikeshed:
+  name: Bikeshed
+  url: https://github.com/dakrone/lein-bikeshed
+  categories: [Code Analysis, Leiningen Plugins]
+  platforms: [clj]
+
+lein_docstring_checker:
+  name: lein-docstring-checker
+  url: https://github.com/camsaul/lein-docstring-checker
+  categories: [Code Analysis, Leiningen Plugins]
+  platforms: [clj]
+
+lein_check_namespace_decls:
+  name: lein-check-namespace-decls
+  url: https://github.com/camsaul/lein-check-namespace-decls
+  categories: [Code Analysis, Leiningen Plugins]
+  platforms: [clj]
+
 stch_routing:
   name: stch.routing
   url: https://github.com/stch-library/routing


### PR DESCRIPTION
I wrote a [new linter](https://github.com/camsaul/lein-check-namespace-decls) today to check that `ns` declaration forms are sorted the same way [`refactor-nrepl`](https://github.com/clojure-emacs/refactor-nrepl)/[`cljr-refactor`](https://github.com/clojure-emacs/clj-refactor.el) would sort them. As far as I can tell no other linters like this exist for Clojure. I thought it would be a nice addition to the toolbox.

I noticed too [Bikeshed](https://github.com/dakrone/lein-bikeshed) is missing from the list. Bikeshed is great complement to Eastwood and would make a great addition. 

Finally, I also added my [docstring-checker linter](https://github.com/camsaul/lein-docstring-checker) which you can use to check whether all public vars in your project have docstrings.

Let me know if any of these don't meet the criteria for going in the toolbox and I'll update the PR.

Thanks!

