### PR TITLE
Add js-interop and introduce Javascript Interop category

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -3778,7 +3778,13 @@ sweet_liberty:
 cljs_oops:
   name: cljs-oops
   url: https://github.com/binaryage/cljs-oops
-  categories: [ClojureScript Development, Syntax Extensions]
+  categories: [ClojureScript Development, Syntax Extensions, Javascript Interop]
+  platforms: [cljs]
+
+js_interop:
+  name: js-interop
+  url: https://github.com/appliedsciencestudio/js-interop
+  categories: [ClojureScript Development, Syntax Extensions, Javascript Interop]
   platforms: [cljs]
 
 graphql_clj:


### PR DESCRIPTION
This adds https://github.com/appliedsciencestudio/js-interop.

Since this library and https://github.com/binaryage/cljs-oops are doing the same (see the [motivation](https://github.com/appliedsciencestudio/js-interop#motivation) for js-interop), I decided to introduce a separate category for them. But if it's not allowed or should be made in a separate PR I'm happy to adjust this one.