### PR TITLE
Remove clj-sql-up

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1222,12 +1222,6 @@ joplin:
   categories: [Database Migrations]
   platforms: [clj]
 
-clj_sql_up:
-  name: clj-sql-up
-  url: https://github.com/ckuttruff/clj-sql-up
-  categories: [Database Migrations]
-  platforms: [clj]
-
 clj_aws_s3:
   name: clj-aws-s3
   url: https://github.com/weavejester/clj-aws-s3


### PR DESCRIPTION
`clj-sql-up` repository is not available anymore (https://github.com/ckuttruff/clj-sql-up returns 404) so I don't think there is any point to keeping this project in the toolbox anymore.