### PR TITLE
Add com.vodori/missing

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -4494,3 +4494,9 @@ datasplash:
   url: https://github.com/ngrunwald/datasplash
   categories: [Google Dataflow]
   platforms: [clj]
+  
+missing:
+  name: Missing
+  url: https://github.com/vodori/missing
+  categories: [Misc. Functions]
+  platforms: [clj]


### PR DESCRIPTION
Add com.vodori/missing - A set of functions intended to complement clojure.core.