### PR TITLE
added polvotech/firestore-clj

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -4500,3 +4500,9 @@ postmortem:
   url: https://github.com/athos/postmortem
   categories: [Debugging]
   platforms: [clj, cljs]
+  
+firestore_clj:
+  name: firestore-clj
+  url: https://github.com/polvotech/firestore-clj
+  categories: [Databases]
+  platforms: [clj]


### PR DESCRIPTION
A Clojure wrapper for Firestore that I've been developing at my company. By now it covers almost all functionalities provided by the underlying java lib, and it has docs.