### PR TITLE
add minicosm

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -3084,6 +3084,12 @@ snes_gamepad:
   url: https://github.com/victorysoftworks/snes-gamepad-cljs
   categories: [Game Development]
   platforms: [cljs]
+  
+minicosm:
+  name: minicosm
+  url: https://github.com/jarcane/minicosm
+  categories: [Game Development]
+  platforms: [cljs]
 
 data_zip:
   name: data.zip


### PR DESCRIPTION
Adds the [minicosm](https://github.com/jarcane/minicosm) game engine to the list.