### PR TITLE
Add Pogonos

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -4608,3 +4608,9 @@ graphqlize:
   url: https://www.graphqlize.org
   categories: [GraphQL]
   platforms: [clj]
+
+pogonos:
+  name: Pogonos
+  url: https://github.com/athos/pogonos
+  categories: [Template Languages]
+  platforms: [clj, cljs]


### PR DESCRIPTION
Added [Pogonos](https://github.com/athos/pogonos), which is another Clojure(Script) implementation of the Mustache templating language.