### PR TITLE
lein-bin should be lein-binplus

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -3698,7 +3698,7 @@ lein_bin:
   platforms: [clj]
 
 lein_binplus:
-  name: lein-bin
+  name: lein-binplus
   url: https://github.com/BrunoBonacci/lein-binplus
   categories: [Command Line Tools, Leiningen Plugins]
   platforms: [clj]


### PR DESCRIPTION
I could guess the original intention but it looks confusing.
![Screenshot from 2020-09-11 18-02-52](https://user-images.githubusercontent.com/40712240/92898833-45e31c80-f459-11ea-9496-acaa6fb02ce9.png)
