### PR TITLE
Add matcher-combinators

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -249,6 +249,12 @@ midje:
   url: https://github.com/marick/Midje
   categories: [Unit Testing]
   platforms: [clj]
+  
+matcher_combinators:
+  name: matcher-combinators
+  url: https://github.com/nubank/matcher-combinators
+  categories: [Unit Testing]  
+  platforms: [clj]  
 
 lazy_test:
   name: Lazytest


### PR DESCRIPTION
matcher-combinators is a useful library in combination with clojure.test or midje, as it allows you to write patterns that your return values get tested againts.