### PR TITLE
add conjure

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -4716,3 +4716,9 @@ keycloak_clojure:
   url: https://github.com/jgrodziski/keycloak-clojure
   categories: [Authentication, Authorization]
   platforms: [clj]
+
+conjure:
+  name: Conjure
+  url: https://github.com/Olical/conjure
+  categories: [Vim Integration]
+  platforms: [clj, cljs]


### PR DESCRIPTION
[Conjure](https://conjure.fun/) is a plugin for Neovim similar to vim-fireplace the main differences are described in this post on [reddit](https://www.reddit.com/r/Clojure/comments/j5inor/conjuring_clojure_in_vim_2020_edition/g8hf7yc/?utm_source=reddit&utm_medium=web2x&context=3). 
And a presentation by Olical (the creator of the plugin) during the [Vimconf 2020](https://www.youtube.com/watch?v=RU28xy9JXxs).