### PR TITLE
add SICMUtils

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -351,6 +351,12 @@ incanter:
   url: http://incanter.org/
   categories: [Statistical Computing, Math]
   platforms: [clj]
+  
+sicmutils:
+  name: SICMUtils
+  url: https://github.com/sicmutils/sicmutils
+  categories: [Functional Programming, Math]
+  platforms: [clj, cljs]
 
 clojail:
   name: Clojail


### PR DESCRIPTION
SICMUtils is a scientific workbench in Clojure and Clojurescript that supports symbolic math (with a great simplification engine), forward mode automatic differentiation and more.