### PR TITLE
Add practicalli/clojure-deps-edn project

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -4417,6 +4417,12 @@ clj_new:
   categories: [tools.deps]
   platforms: [clj]
 
+practicalli_clojure_deps_edn:
+  name: practicalli-clojure-deps-edn
+  url: https://github.com/practicalli/clojure-deps-edn
+  categories: [tools.deps]
+  platform: [clj]
+
 dot_clojure_deps_edn:
   name: dot-clojure-deps.edn
   url: https://github.com/seancorfield/dot-clojure


### PR DESCRIPTION
Project provides comprehensive aliases for community tools and library repository configurations