### PR TITLE
Added `java-http-clj` HTTP client

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -340,6 +340,12 @@ hato:
   categories: [HTTP Clients]
   platforms: [clj]
 
+java-http-clj:
+  name: java-http-clj
+  url: https://github.com/schmee/java-http-clj
+  categories: [HTTP Clients, Websockets, Asynchronous HTTP]
+  platforms: [clj]
+
 ring_httpcore_adapter:
   name: ring-httpcore-adapter
   url: https://github.com/mmcgrana/ring-httpcore-adapter

--- a/projects.yml
+++ b/projects.yml
@@ -340,7 +340,7 @@ hato:
   categories: [HTTP Clients]
   platforms: [clj]
 
-java-http-clj:
+java_http_clj:
   name: java-http-clj
   url: https://github.com/schmee/java-http-clj
   categories: [HTTP Clients, Websockets, Asynchronous HTTP]


### PR DESCRIPTION
[`java-http-clj`](https://github.com/schmee/java-http-clj) is a lightweight HTTP client based on `java.net.http` shipped in Java 11. It includes support for async requests and Websockets.