### PR TITLE
Added Cljfx library

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -670,6 +670,12 @@ quil:
   categories: [Graphics]
   platforms: [clj, cljs]
 
+cljfx:
+  name: Cljfx
+  url: https://github.com/cljfx/cljfx
+  categories: [Graphics, GUIs]
+  platforms: [clj]
+
 pallet:
   name: Pallet
   url: http://pallet.github.com/pallet/


### PR DESCRIPTION
[Cljfx](https://github.com/cljfx/cljfx) is a functional wrapper for JavaFX.

Fixes #357