### PR TITLE
Added `pick` library

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -4081,6 +4081,12 @@ ring_accept_param:
   categories: [Content Negotiation, Request Middleware]
   platforms: [clj]
 
+pick:
+  name: pick
+  url: https://github.com/juxt/pick
+  categories: [Content Negotiation]
+  platforms: [clj]
+
 multigrep:
   name: multigrep
   url: https://github.com/clj-commons/multigrep


### PR DESCRIPTION
[pick](https://github.com/juxt/pick) is a Clojure library for HTTP server-driven content negotiation.