### PR TITLE
Added various spec, schema and validation libs

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -583,7 +583,25 @@ tubax:
 clj_xml_validation:
   name: clj-xml-validation
   url: https://github.com/bbbates/clj-xml-validation
-  categories: [XML Schema]
+  categories: [XML Schema, Validation]
+  platforms: [clj]
+
+jinx:
+  name: jinx
+  url: https://github.com/juxt/jinx
+  categories: [Schema, Validation]
+  platforms: [clj, cljs]
+
+scjsv:
+  name: scjsv
+  url: https://github.com/metosin/scjsv
+  categories: [Schema, Validation]
+  platforms: [clj]
+
+json_schema:
+  name: json-schema
+  url: https://github.com/luposlip/json-schema
+  categories: [Schema, Validation]
   platforms: [clj]
 
 lamina:
@@ -2826,7 +2844,7 @@ core_typed:
 
 schema:
   name: Schema
-  url: https://github.com/Prismatic/schema
+  url: https://github.com/plumatic/schema
   categories: [Schema, Validation, Random Data Generation, Syntax Extensions, Dynamic Typing]
   platforms: [clj, cljs]
 
@@ -4342,7 +4360,7 @@ missionary:
 spec_alpha:
   name: spec.alpha
   url: https://github.com/clojure/spec.alpha
-  categories: [Spec, Schema, Dynamic Typing]
+  categories: [Spec, Schema, Dynamic Typing, Validation]
   platforms: [clj, cljs]
 
 spec_coerce:
@@ -4351,11 +4369,41 @@ spec_coerce:
   categories: [Spec, Data Coercion]
   platforms: [clj, cljs]
 
+coax:
+  name: coax
+  url: https://github.com/exoscale/coax
+  categories: [Spec, Data Coercion]
+  platforms: [clj, cljs]
+
 clojure_future_spec:
   name: clojure-future-spec
   url: https://github.com/tonsky/clojure-future-spec
   categories: [Spec]
   platforms: [clj]
+
+malli:
+  name: malli
+  url: https://github.com/metosin/malli
+  categories: [Schema, Dynamic Typing, Validation, Random Data Generation]
+  platforms: [clj, cljs]
+
+minimallist:
+  name: minimallist
+  url: https://github.com/green-coder/minimallist
+  categories: [Schema, Dynamic Typing, Validation, Random Data Generation]
+  platforms: [clj, cljs]
+
+spec_provider:
+  name: spec-provider
+  url: https://github.com/stathissideris/spec-provider
+  categories: [Spec, Schema]
+  platforms: [clj, cljs]
+
+struct:
+  name: struct
+  url: https://github.com/funcool/struct
+  categories: [Schema, Validation]
+  platforms: [clj, cljs]
 
 expound:
   name: Expound

--- a/projects.yml
+++ b/projects.yml
@@ -583,25 +583,25 @@ tubax:
 clj_xml_validation:
   name: clj-xml-validation
   url: https://github.com/bbbates/clj-xml-validation
-  categories: [XML Schema, Validation]
+  categories: [XML Schema]
   platforms: [clj]
 
 jinx:
   name: jinx
   url: https://github.com/juxt/jinx
-  categories: [Schema, Validation]
+  categories: [Schema]
   platforms: [clj, cljs]
 
 scjsv:
   name: scjsv
   url: https://github.com/metosin/scjsv
-  categories: [Schema, Validation]
+  categories: [Schema]
   platforms: [clj]
 
 json_schema:
   name: json-schema
   url: https://github.com/luposlip/json-schema
-  categories: [Schema, Validation]
+  categories: [Schema]
   platforms: [clj]
 
 lamina:

--- a/projects.yml
+++ b/projects.yml
@@ -589,19 +589,19 @@ clj_xml_validation:
 jinx:
   name: jinx
   url: https://github.com/juxt/jinx
-  categories: [Schema]
+  categories: [JSON Schema]
   platforms: [clj, cljs]
 
 scjsv:
   name: scjsv
   url: https://github.com/metosin/scjsv
-  categories: [Schema]
+  categories: [JSON Schema]
   platforms: [clj]
 
 json_schema:
   name: json-schema
   url: https://github.com/luposlip/json-schema
-  categories: [Schema]
+  categories: [JSON Schema]
   platforms: [clj]
 
 lamina:

--- a/projects.yml
+++ b/projects.yml
@@ -4384,13 +4384,13 @@ clojure_future_spec:
 malli:
   name: malli
   url: https://github.com/metosin/malli
-  categories: [Schema, Dynamic Typing, Validation, Random Data Generation]
+  categories: [Schema, Validation, Random Data Generation]
   platforms: [clj, cljs]
 
 minimallist:
   name: minimallist
   url: https://github.com/green-coder/minimallist
-  categories: [Schema, Dynamic Typing, Validation, Random Data Generation]
+  categories: [Schema, Validation, Random Data Generation]
   platforms: [clj, cljs]
 
 spec_provider:


### PR DESCRIPTION
- [jinx](https://github.com/juxt/jinx), [scjsv](https://github.com/metosin/scjsv) and [json-schema](https://github.com/luposlip/json-schema) are JSON schema validators
- [coax](https://github.com/exoscale/coax) is a clojure.spec coercion library, based on [spec-coerce](https://github.com/wilkerlucio/spec-coerce)
- [malli](https://github.com/metosin/malli) is a data-driven schema library
- [minimallist](https://github.com/green-coder/minimallist) is an minimalist alternative to spec and malli
- [spec-provider](https://github.com/stathissideris/spec-provider) infers specs from sample data
- [struct](https://github.com/funcool/struct) is a structural validation library