### PR TITLE
Added Polylith architecture tool

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -2686,6 +2686,12 @@ trapperkeeper:
   categories: [Application Frameworks]
   platforms: [clj]
 
+polylith:
+  name: Polylith
+  url: https://github.com/polyfy/polylith
+  categories: [Application Architectures]
+  platforms: [clj]
+
 jig:
   name: Jig
   url: https://github.com/juxt/jig

--- a/projects.yml
+++ b/projects.yml
@@ -2689,7 +2689,7 @@ trapperkeeper:
 polylith:
   name: Polylith
   url: https://github.com/polyfy/polylith
-  categories: [Application Architectures]
+  categories: [Application Frameworks]
   platforms: [clj]
 
 jig:


### PR DESCRIPTION
[Polylith](https://github.com/polyfy/polylith) is a tool used to develop Polylith based architectures in Clojure. See also the [Polylith high level overview](https://polylith.gitbook.io/polylith/)

Please note this is not an application framework, hence the choice of category `Application Architectures`.

Fixes #393