### PR TITLE
Updated various instrumentation libraries

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -2868,7 +2868,7 @@ herbert:
 
 annotate:
   name: Annotate
-  url: https://github.com/roomkey/annotate
+  url: https://github.com/coconutpalm/annotate
   categories: [Schema, Validation, Syntax Extensions, Dynamic Typing]
   platforms: [clj]
 
@@ -4423,22 +4423,28 @@ expound:
   categories: [Spec]
   platforms: [clj, cljs]
 
+aave:
+  name: aave
+  url: https://github.com/teknql/aave
+  categories: [Dynamic Typing]
+  platforms: [clj, cljs]
+
 orchestra:
   name: Orchestra
   url: https://github.com/jeaye/orchestra
-  categories: [Spec]
+  categories: [Spec, Dynamic Typing]
   platforms: [clj, cljs]
 
 ghostwheel:
   name: Ghostwheel
   url: https://github.com/gnl/ghostwheel
-  categories: [Spec, Debugging, Unit Testing]
+  categories: [Spec, Debugging, Unit Testing, Dynamic Typing]
   platforms: [clj, cljs]
 
 guardrails:
   name: Guardrails
   url: https://github.com/fulcrologic/guardrails
-  categories: [Spec]
+  categories: [Spec, Dynamic Typing]
   platforms: [clj, cljs]
 
 spectrum:


### PR DESCRIPTION
- [annotate](https://github.com/coconutpalm/annotate) repository has relocated and is no longer available at https://github.com/roomkey/annotate
- Added [aave](https://github.com/teknql/aave) which offers function instrumentation and stubbing, with checking powered by [malli](https://github.com/metosin/malli)
- Added `Dynamic Typing` category to [orchestra](https://github.com/jeaye/orchestra), [ghostwheel](https://github.com/gnl/ghostwheel) and [guardrails](https://github.com/fulcrologic/guardrails), as all these libraries offer function checking by instrumentation