### PR TITLE
Updated and added various debugging libraries

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1056,7 +1056,7 @@ lein_cdt:
 
 dr_evil:
   name: Dr. Evil
-  url: https://bitbucket.org/tebeka/dr-evil/src
+  url: https://github.com/tebeka/dr-evil
   categories: [Debugging]
   platforms: [clj]
 
@@ -1068,7 +1068,7 @@ ritz:
 
 sayid:
   name: Sayid
-  url: http://bpiel.github.io/sayid/
+  url: https://github.com/clojure-emacs/sayid
   categories: [Debugging]
   platforms: [clj]
 
@@ -1081,6 +1081,24 @@ spyscope:
 scope_capture:
   name: scope-capture
   url: https://github.com/vvvvalvalval/scope-capture
+  categories: [Debugging]
+  platforms: [clj, cljs]
+
+hashp:
+  name: hashp
+  url: https://github.com/weavejester/hashp
+  categories: [Debugging]
+  platforms: [clj, cljs]
+
+mate_clj:
+  name: mate-clj
+  url: https://github.com/AppsFlyer/mate-clj
+  categories: [Debugging]
+  platforms: [clj]
+
+flow_storm_debugger:
+  name: Flow-storm debugger
+  url: https://github.com/jpmonettas/flow-storm-debugger
   categories: [Debugging]
   platforms: [clj, cljs]
 


### PR DESCRIPTION
- Fixed broken links for [Dr. Evil](https://github.com/tebeka/dr-evil) and [Sayid](https://github.com/clojure-emacs/sayid) - Fixes #374
- [hashp](https://github.com/weavejester/hashp) is a better `prn` for Clojure/ClojureScript (but you knew that already :) )
- [mate-clj](https://github.com/AppsFlyer/mate-clj) is a library for debugging the flow through Clojure core functions in your own programs
- [Flow-storm debugger](https://github.com/jpmonettas/flow-storm-debugger) is a debugger for Clojure and ClojureScript