### PR TITLE
Added data serialization libraries

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -2704,10 +2704,22 @@ uncaught:
   categories: [Exception Handling]
   platforms: [clj]
 
+cawasser_protobuf:
+  name: cawasser/protobuf
+  url: https://github.com/cawasser/protobuf
+  categories: [Data Serialization, Schema]
+  platforms: [clj]
+
+lancaster:
+  name: Lancaster
+  url: https://github.com/deercreeklabs/lancaster
+  categories: [Data Serialization, Schema]
+  platforms: [clj, cljs]
+
 abracad:
   name: Abracad
   url: https://github.com/damballa/abracad
-  categories: [Data Serialization]
+  categories: [Data Serialization, Schema]
   platforms: [clj]
 
 useful:


### PR DESCRIPTION
- [cawasser/protobuf](https://github.com/cawasser/protobuf) is a Clojure interface to Google protocol buffers (protobuf). This is the most recently maintained fork of [ninjudd/clojure-protobuf](https://github.com/ninjudd/clojure-protobuf)
- [Lancaster](https://github.com/deercreeklabs/lancaster) is a library for working with Apache Avro