### PR TITLE
Added clj-camel library

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -5080,5 +5080,5 @@ keenest_rube:
 clj_camel:
   name: clj-camel
   url: https://github.com/TakeoffTech/clj-camel
-  categories: [Enterprise Integration Patterns, Message-oriented Middleware]
+  categories: [Enterprise Integration Patterns]
   platforms: [clj]

--- a/projects.yml
+++ b/projects.yml
@@ -5076,3 +5076,9 @@ keenest_rube:
   url: https://github.com/blak3mill3r/keenest-rube
   categories: [Kubernetes Clients]
   platforms: [clj]
+
+clj_camel:
+  name: clj-camel
+  url: https://github.com/TakeoffTech/clj-camel
+  categories: [Enterprise Integration Patterns, Message-oriented Middleware]
+  platforms: [clj]


### PR DESCRIPTION
[clj-camel](https://github.com/TakeoffTech/clj-camel) - adds a thin layer on top of Java Apache Camel and provides a more idiomatic experience of using Apache Camel in the Clojure ecosystem, without changing the original functionality