### PR TITLE
Added Timbre logging extension libraries

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -2254,6 +2254,18 @@ timbre:
   categories: [Logging]
   platforms: [clj, cljs]
 
+timbre_json_appender:
+  name: timbre-json-appender
+  url: https://github.com/viesti/timbre-json-appender
+  categories: [Logging]
+  platforms: [clj]
+
+clj_loga:
+  name: clj-loga
+  url: https://github.com/FundingCircle/clj-loga
+  categories: [Logging]
+  platforms: [clj]
+
 tufte:
   name: Tufte
   url: https://github.com/ptaoussanis/tufte


### PR DESCRIPTION
- [timbre-json-appender](https://github.com/viesti/timbre-json-appender) is a JSON appender for Timbre
- [clj-loga](https://github.com/FundingCircle/clj-loga) is another JSON appender, with tagging and obfuscation features