### PR TITLE
Added CRDT libraries

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1810,6 +1810,18 @@ immutable_bitset:
   categories: [Data Structures, Performance]
   platforms: [clj]
 
+Cause:
+  name: Cause
+  url: https://github.com/smothers/cause
+  categories: [Data Structures]
+  platforms: [clj, cljs]
+
+schism:
+  name: schism
+  url: https://github.com/aredington/schism
+  categories: [Data Structures]
+  platforms: [clj, cljs]
+
 shake:
   name: Shake
   url: https://github.com/sunng87/shake


### PR DESCRIPTION
Added these Conflict-free Replicated Data Types (CRDTs) libraries:
- [Cause](https://github.com/smothers/cause) is an EDN-like CRDT (Causal Tree) that automatically tracks history and resolves conflicts
- [schism](https://github.com/aredington/schism) provides CRDTs with EDN Serialization