### PR TITLE
Added infrastructure provisioning tools and libs

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -832,6 +832,18 @@ pallet:
   categories: [Infrastructure Provisioning]
   platforms: [clj]
 
+dda_pallet:
+  name: dda-pallet
+  url: https://github.com/DomainDrivenArchitecture/dda-pallet
+  categories: [Infrastructure Provisioning]
+  platforms: [clj]
+
+pulumi_cljs:
+  name: pulumi-cljs
+  url: https://github.com/modern-energy/pulumi-cljs
+  categories: [Infrastructure Provisioning]
+  platforms: [cljs]
+
 cascalog:
   name: Cascalog
   url: https://github.com/nathanmarz/cascalog


### PR DESCRIPTION
- [dda-pallet](https://github.com/DomainDrivenArchitecture/dda-pallet) is a provisioning and configuration system that enables a user provided abstraction layer. It is built on (but not part of) the [pallet](https://github.com/pallet/pallet) project.
- [pulumi-cljs](https://github.com/modern-energy/pulumi-cljs) is a ClojureScript wrapper for [Pulumi](https://www.pulumi.com/)