### PR TITLE
Added tracing libraries

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -145,7 +145,31 @@ safely:
 mulog:
   name: Mulog (μ/log)
   url: https://github.com/BrunoBonacci/mulog
-  categories: [Logging, Metrics]
+  categories: [Logging, Metrics, Tracing]
+  platforms: [clj]
+
+clj_otel:
+  name: clj-otel
+  url: https://github.com/steffan-westcott/clj-otel
+  categories: [Tracing]
+  platforms: [clj]
+
+opencensus_clojure:
+  name: opencensus-clojure
+  url: https://github.com/uswitch/opencensus-clojure
+  categories: [Tracing]
+  platforms: [clj]
+
+opentracing_clj:
+  name: opentracing-clj
+  url: https://github.com/alvinfrancis/opentracing-clj
+  categories: [Tracing]
+  platforms: [clj]
+
+ken:
+  name: ken
+  url: https://github.com/amperity/ken
+  categories: [Tracing]
   platforms: [clj]
 
 compojure:
@@ -1201,7 +1225,7 @@ flow_storm_debugger:
 omni_trace:
   name: omni-trace
   url: https://github.com/cyrik/omni-trace
-  categories: [Debugging]
+  categories: [Debugging, Tracing]
   platforms: [clj, cljs]
 
 mandoline:
@@ -2401,7 +2425,7 @@ clearley:
 tools_trace:
   name: tools.trace
   url: https://github.com/clojure/tools.trace
-  categories: [Debugging]
+  categories: [Debugging, Tracing]
   platforms: [clj]
 
 timbre:


### PR DESCRIPTION
- Added the following libraries with a new `Tracing` category:
  - [`clj-otel`](https://github.com/steffan-westcott/clj-otel) is a Clojure API for adding trace telemetry using [OpenTelemetry](https://opentelemetry.io/)
  - [`opencensus-clojure`](https://github.com/uswitch/opencensus-clojure) is a Clojure wrapper for [`opencensus-java`](https://github.com/census-instrumentation/opencensus-java)
  - [`opentracing-clj`](https://github.com/alvinfrancis/opentracing-clj) is a Clojure wrapper for [`opentracing-java`](https://github.com/opentracing/opentracing-java)
  - [`ken`](https://github.com/amperity/ken) is an observability library for instrumenting Clojure code, which supports tracing
- Added the `Tracing` category to existing entries `Mulog`, `omni-trace` and `tools.trace`