### PR TITLE
Add True Grit resilience library

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -5406,3 +5406,9 @@ salutem:
   url: https://github.com/logicblocks/salutem
   categories: [Monitoring, Metrics]
   platforms: [clj]
+
+truegrit:
+  name: True Grit
+  url: https://github.com/KingMob/TrueGrit
+  categories: [Retrying Failures]
+  platforms: [clj]


### PR DESCRIPTION
My apologies if I was supposed to add an issue, it wasn't clear.

Anyway, I'd like to add my True Grit library. It's just been made publicly available today, but it's been in use in production for a couple years.