### PR TITLE
clj-aws-s3 is deprecated in favor of amazonica

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1588,12 +1588,6 @@ aws_api:
   categories: [Amazon Web Services (AWS)]
   platforms: [clj]
 
-clj_aws_s3:
-  name: clj-aws-s3
-  url: https://github.com/weavejester/clj-aws-s3
-  categories: [Amazon Web Services (AWS)]
-  platforms: [clj]
-
 codox:
   name: Codox
   url: https://github.com/weavejester/codox


### PR DESCRIPTION
see https://github.com/weavejester/clj-aws-s3