### PR TITLE
Adds clj-alpakka-kafka to Kafka client

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -4478,6 +4478,12 @@ ziggurat:
   categories: [Kafka Clients]
   platforms: [clj]
 
+clj_alpakka_kafka:
+  name: clj-alpakka-kafka
+  url: https://github.com/fr33m0nk/clj-alpakka-kafka
+  categories: [Kafka Clients]
+  platforms: [clj]
+
 relational_mapper:
   name: Relational Mapper
   url: https://github.com/netizer/relational_mapper


### PR DESCRIPTION
This PR adds `clj-alpakka-kafka` to Kafka client category.
It is a Clojure wrapper over Alpakka Kafka.