### PR TITLE
Update Cambium - remove cljs

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -1448,7 +1448,7 @@ cambium:
   name: Cambium
   url: https://cambium-clojure.github.io/
   categories: [Logging]
-  platforms: [clj, cljs]
+  platforms: [clj]
 
 ring_logger:
   name: Ring-logger


### PR DESCRIPTION
Cambium doesn't support cljs

I checked with the author, Shantanu Kumar, in #cambium: "Cambium is based on SLF4j, hence very JVM specific."