### PR TITLE
Add typedclojure

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -3315,6 +3315,12 @@ core_typed:
   categories: [Static Typing, Syntax Extensions]
   platforms: [clj]
 
+typedclojure:
+  name: typedclojure
+  url: https://github.com/typedclojure/typedclojure
+  categories: [Static Typing, Syntax Extensions]
+  platforms: [clj, cljs]
+
 schema:
   name: Schema
   url: https://github.com/plumatic/schema


### PR DESCRIPTION
core.typed repo mentions it being [deprecated](https://github.com/clojure/core.typed?tab=readme-ov-file#new-repo----coretyped-is-deprecated-as-of-clojure-111). I have only added `typedclojure` in the PR but maybe replacing core.typed is the better course of action.