### PR TITLE
Switch to maintained version of Lazytest

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -358,8 +358,8 @@ matcher_combinators:
 
 lazy_test:
   name: Lazytest
-  url: https://github.com/stuartsierra/lazytest
-  categories: [Unit Testing]
+  url: https://github.com/noahtheduke/lazytest
+  categories: [Unit Testing, Test Runners]
   platforms: [clj]
 
 test_check:


### PR DESCRIPTION
Sandra archived Lazytest back in 2013. I forked it last year and have been regularly publishing new releases.