### PR TITLE
Add `clj-tg-bot-api` library

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -3719,6 +3719,13 @@ deed:
   platforms: [clj]
   description: Fast, flexible, 0-deps (de)serialization library for Clojure
 
+clj-tg-bot-api:
+  name: Clojure Telegram Bot API
+  url: https://github.com/marksto/clj-tg-bot-api
+  categories: [Telegram]
+  platforms: [clj]
+  description: The latest Telegram Bot API specification and client lib for Clojure-based apps
+
 teleward:
   name: Teleward
   url: https://github.com/igrishaev/teleward

--- a/projects.yml
+++ b/projects.yml
@@ -3719,7 +3719,7 @@ deed:
   platforms: [clj]
   description: Fast, flexible, 0-deps (de)serialization library for Clojure
 
-clj-tg-bot-api:
+clj_tg_bot_api:
   name: Clojure Telegram Bot API
   url: https://github.com/marksto/clj-tg-bot-api
   categories: [Telegram]


### PR DESCRIPTION
@weavejester Hi James! It would be nice to have the [clj-tg-bot-api](https://github.com/marksto/clj-tg-bot-api) library listed on the site. Thank you for a great resource!