### PR TITLE
add Oak

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -6388,3 +6388,10 @@ makina:
   categories: [Reloaded Workflow]
   platforms: [clj]
   description: Clojure System/component lifecycle management
+
+Oak:
+  name: Oak
+  url: https://git.gaiwan.co/gaiwan/Oak
+  categories: [Authentication, Authorization, Password Security]
+  platforms: [clj]
+  description: Headless Identity Provider (idp) service that supports OAuth 2.0, OpenID Connect and 2FA.

--- a/projects.yml
+++ b/projects.yml
@@ -6389,7 +6389,7 @@ makina:
   platforms: [clj]
   description: Clojure System/component lifecycle management
 
-Oak:
+oak:
   name: Oak
   url: https://git.gaiwan.co/gaiwan/Oak
   categories: [Authentication, Authorization, Password Security]


### PR DESCRIPTION
## Add an self-hosted Clojure-based IAM/IDP service

- It is **not** a library, but a self-hosted service. 
- It is an alternative to KeyCloak although it does not support LDAP, Active Directory currently. 
- Its special feature is that it is `headless`. 
- It is made by Clojure.
- [release note](https://gaiwan.co/blog/announcing-oak-1-0/). 